### PR TITLE
Scroll list implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This script uses the `lsdvd` commandline utility to allow users to view and select titles for DVDs from directly within mpv.
 The browser is interractive and allows for both playing the selected title, or appending it to the playlist.
 
+This script requires [mpv-scroll-list](https://github.com/CogentRedTester/mpv-scroll-list) to work, simply place `scroll-list.lua` into the `~~/scripts` folder.
+
 ## Browser
 The browser provides useful information to help choose which title to play.
 Currently it just shows track length and the number of chapters, but this may be expanded in the future to show track information as well.

--- a/dvd-browser.lua
+++ b/dvd-browser.lua
@@ -134,14 +134,8 @@ list.format_line = function(this, i, v)
         this:newline()
 end
 
---this function updates dvd information and updates the browser
-function update()
-    read_disc()
-    list:update()
-end
-
 --sends a call to lsdvd to read the contents of the disc
-function read_disc()
+local function read_disc()
     msg.verbose('reading contents of ' .. o.dvd_device)
 
     local args
@@ -227,6 +221,12 @@ function read_disc()
 
     state.playing_disc = true
     list.list = dvd.track
+end
+
+--this function updates dvd information and updates the browser
+local function update()
+    read_disc()
+    list:update()
 end
 
 --appends the specified playlist item along with the desired options
@@ -321,7 +321,7 @@ local function load_disc()
 end
 
 --opens the currently selected file
-function open_file(flag)
+local function open_file(flag)
     load_dvd_title(dvd.track[list.selected], flag)
 
     if flag == 'replace' then
@@ -330,7 +330,7 @@ function open_file(flag)
 end
 
 --for file-browser compatibility
-function up_dir()
+local function up_dir()
     local dir
 
     if (o.wsl) then dir = mp.get_property('dvd-device', '')
@@ -352,7 +352,7 @@ function up_dir()
 end
 
 --opens the browser and declares dynamic keybinds
-function open_browser()
+local function open_browser()
     if not state.playing_disc then
         update()
     else
@@ -375,6 +375,7 @@ local file_browser_keybinds = {
     {'Shift+HOME', 'root', function() list:close() ; mp.commandv('script-message', 'goto-root-directory') end, {}}
 }
 
+--adds the file-browser keybinds to the keybinds array
 if o.file_browser then
     local back = #list.keybinds
     for i = 1, #file_browser_keybinds do

--- a/dvd-browser.lua
+++ b/dvd-browser.lua
@@ -352,12 +352,14 @@ local function up_dir()
 end
 
 --opens the browser and declares dynamic keybinds
-local function open_browser()
+list.open = function(this)
+    this.hidden = false
     if not state.playing_disc then
         update()
     else
-        list:open()
+        this:open_list()
     end
+    this:add_keybinds()
 end
 
 list.keybinds = {
@@ -402,12 +404,6 @@ mp.observe_property('path', 'string', function(_,path)
     if state.playing_disc then list:update() end
 end)
 
-mp.register_script_message('browse-dvd', open_browser)
+mp.register_script_message('browse-dvd', function() list:open() end)
 
-mp.add_key_binding('MENU', 'dvd-browser', function()
-    if ov.hidden then
-        open_browser()
-    else
-        list:close()
-    end
-end)
+mp.add_key_binding('MENU', 'dvd-browser', function() list:toggle() end)


### PR DESCRIPTION
The script now requires that mpv-scroll-list to use the browser.

This simplifies development of these scripts by moving common code
into a single external lua module.

There should be no lost functionality.